### PR TITLE
Improve error handling and reporting for installs

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
                  [org.clojure/clojure-contrib "1.2.0"]
                  [org.clojure/data.json "0.1.1"]
                  [digest "1.4.0"]
-                 [progress "1.0.1"]]
+                 [progress "1.0.1"]
+                 [clj-http-lite "0.2.0"]]
   :dev-dependencies [[lein-clojars "0.7.0"]]
   :aliases {"overlay" ["run" "-m" "overlay.main"]})


### PR DESCRIPTION
This is a sizeable refactor of the way that the Overlay project handles 
downloading and installing artifacts. Highlights include:
- Adds a protocol for BinaryArtifacts and adds two implementations for
  Incremental and Release builds. The protocol includes functions to
  retrieve the remote URL and the download file size.
- Utilizes a HEAD request to determine file size when a metadata file is
  not available.
- Checks for 404s before attempting a download. Fails more gracefully
  when something goes wrong during download.

In order to support all these changes, one additional dependency was added:
clj-http-lite.
